### PR TITLE
feat(applicationset): add ApplicationSet controller and CRD definitions

### DIFF
--- a/middlewares/argocd/install-appset-controller.yaml
+++ b/middlewares/argocd/install-appset-controller.yaml
@@ -1,0 +1,1564 @@
+# This is an auto-generated file. DO NOT EDIT
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+namespace: argocd
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: applicationsets.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ApplicationSet
+    listKind: ApplicationSetList
+    plural: applicationsets
+    singular: applicationset
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ApplicationSet is a set of Application resources
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApplicationSetSpec represents a class of application set state.
+            properties:
+              generators:
+                items:
+                  description: ApplicationSetGenerator include list item info
+                  properties:
+                    clusters:
+                      description: ClusterGenerator defines a generator to match against clusters registered with ArgoCD.
+                      properties:
+                        selector:
+                          description: Selector defines a label selector to match against all clusters registered with ArgoCD. Clusters today are stored as Kubernetes Secrets, thus the Secret labels will be used for matching the selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        template:
+                          description: ApplicationSetTemplate represents argocd ApplicationSpec
+                          properties:
+                            metadata:
+                              description: ApplicationSetTemplateMeta represents the Argo CD application fields that may be used for Applications generated from the ApplicationSet (based on metav1.ObjectMeta)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+                              properties:
+                                destination:
+                                  description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+                                  properties:
+                                    name:
+                                      description: Name of the destination cluster which can be used instead of server (url) field
+                                      type: string
+                                    namespace:
+                                      description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                                      type: string
+                                    server:
+                                      description: Server overrides the environment server value in the ksonnet app.yaml
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  description: IgnoreDifferences controls resources fields which should be ignored during comparison
+                                  items:
+                                    description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
+                                    properties:
+                                      group:
+                                        type: string
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - jsonPointers
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  description: Project is a application project name. Empty name means that application belongs to 'default' project.
+                                  type: string
+                                revisionHistoryLimit:
+                                  description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+                                  format: int64
+                                  type: integer
+                                source:
+                                  description: Source is a reference to the location ksonnet application definition
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory specific options
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        jsonnet:
+                                          description: ApplicationSourceJsonnet holds jsonnet specific options
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet External Variables
+                                              items:
+                                                description: JsonnetVar is a jsonnet variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet Top-level Arguments
+                                              items:
+                                                description: JsonnetVar is a jsonnet variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        fileParameters:
+                                          description: FileParameters are file parameters to the helm template
+                                          items:
+                                            description: HelmFileParameter is a file parameter to a helm template
+                                            properties:
+                                              name:
+                                                description: Name is the name of the helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path value for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        parameters:
+                                          description: Parameters are parameters to the helm template
+                                          items:
+                                            description: HelmParameter is a parameter to a helm template
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        releaseName:
+                                          description: The Helm release name. If omitted it will use the application name
+                                          type: string
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm value files to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values is Helm values, typically defined as a block
+                                          type: string
+                                        version:
+                                          description: Version is the Helm version to use for templating with
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      description: Ksonnet holds ksonnet specific options
+                                      properties:
+                                        environment:
+                                          description: Environment is a ksonnet application environment name
+                                          type: string
+                                        parameters:
+                                          description: Parameters are a list of ksonnet component parameter override values
+                                          items:
+                                            description: KsonnetParameter is a ksonnet component parameter
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific options
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations adds additional kustomize commonAnnotations
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels adds additional kustomize commonLabels
+                                          type: object
+                                        images:
+                                          description: Images are kustomize image overrides
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended to resources for kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended to resources for kustomize apps
+                                          type: string
+                                        version:
+                                          description: Version contains optional Kustomize version
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within the Git repository
+                                      type: string
+                                    plugin:
+                                      description: ConfigManagementPlugin holds config management plugin specific options
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                description: the name, usually uppercase
+                                                type: string
+                                              value:
+                                                description: the value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      description: RepoURL is the repository URL of the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  description: SyncPolicy controls when a sync will be performed
+                                  properties:
+                                    automated:
+                                      description: Automated will keep an application synced to the target revision
+                                      properties:
+                                        allowEmpty:
+                                          description: 'AllowEmpty allows apps have zero live resources (default: false)'
+                                          type: boolean
+                                        prune:
+                                          description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                                          type: boolean
+                                        selfHeal:
+                                          description: 'SelfHeal enables auto-syncing if  (default: false)'
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      description: Retry controls failed sync retry behavior
+                                      properties:
+                                        backoff:
+                                          description: Backoff is a backoff strategy
+                                          properties:
+                                            duration:
+                                              description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                                              type: string
+                                            factor:
+                                              description: Factor is a factor to multiply the base duration after each failed retry
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                                              type: string
+                                          type: object
+                                        limit:
+                                          description: Limit is the maximum number of attempts when retrying a container
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      description: Options allow you to specify whole app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                        values:
+                          additionalProperties:
+                            type: string
+                          description: Values contains key/value pairs which are passed directly as parameters to the template
+                          type: object
+                      type: object
+                    git:
+                      properties:
+                        directories:
+                          items:
+                            properties:
+                              path:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        files:
+                          items:
+                            properties:
+                              path:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        repoURL:
+                          type: string
+                        requeueAfterSeconds:
+                          format: int64
+                          type: integer
+                        revision:
+                          type: string
+                        template:
+                          description: ApplicationSetTemplate represents argocd ApplicationSpec
+                          properties:
+                            metadata:
+                              description: ApplicationSetTemplateMeta represents the Argo CD application fields that may be used for Applications generated from the ApplicationSet (based on metav1.ObjectMeta)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+                              properties:
+                                destination:
+                                  description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+                                  properties:
+                                    name:
+                                      description: Name of the destination cluster which can be used instead of server (url) field
+                                      type: string
+                                    namespace:
+                                      description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                                      type: string
+                                    server:
+                                      description: Server overrides the environment server value in the ksonnet app.yaml
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  description: IgnoreDifferences controls resources fields which should be ignored during comparison
+                                  items:
+                                    description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
+                                    properties:
+                                      group:
+                                        type: string
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - jsonPointers
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  description: Project is a application project name. Empty name means that application belongs to 'default' project.
+                                  type: string
+                                revisionHistoryLimit:
+                                  description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+                                  format: int64
+                                  type: integer
+                                source:
+                                  description: Source is a reference to the location ksonnet application definition
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory specific options
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        jsonnet:
+                                          description: ApplicationSourceJsonnet holds jsonnet specific options
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet External Variables
+                                              items:
+                                                description: JsonnetVar is a jsonnet variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet Top-level Arguments
+                                              items:
+                                                description: JsonnetVar is a jsonnet variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        fileParameters:
+                                          description: FileParameters are file parameters to the helm template
+                                          items:
+                                            description: HelmFileParameter is a file parameter to a helm template
+                                            properties:
+                                              name:
+                                                description: Name is the name of the helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path value for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        parameters:
+                                          description: Parameters are parameters to the helm template
+                                          items:
+                                            description: HelmParameter is a parameter to a helm template
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        releaseName:
+                                          description: The Helm release name. If omitted it will use the application name
+                                          type: string
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm value files to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values is Helm values, typically defined as a block
+                                          type: string
+                                        version:
+                                          description: Version is the Helm version to use for templating with
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      description: Ksonnet holds ksonnet specific options
+                                      properties:
+                                        environment:
+                                          description: Environment is a ksonnet application environment name
+                                          type: string
+                                        parameters:
+                                          description: Parameters are a list of ksonnet component parameter override values
+                                          items:
+                                            description: KsonnetParameter is a ksonnet component parameter
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific options
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations adds additional kustomize commonAnnotations
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels adds additional kustomize commonLabels
+                                          type: object
+                                        images:
+                                          description: Images are kustomize image overrides
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended to resources for kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended to resources for kustomize apps
+                                          type: string
+                                        version:
+                                          description: Version contains optional Kustomize version
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within the Git repository
+                                      type: string
+                                    plugin:
+                                      description: ConfigManagementPlugin holds config management plugin specific options
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                description: the name, usually uppercase
+                                                type: string
+                                              value:
+                                                description: the value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      description: RepoURL is the repository URL of the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  description: SyncPolicy controls when a sync will be performed
+                                  properties:
+                                    automated:
+                                      description: Automated will keep an application synced to the target revision
+                                      properties:
+                                        allowEmpty:
+                                          description: 'AllowEmpty allows apps have zero live resources (default: false)'
+                                          type: boolean
+                                        prune:
+                                          description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                                          type: boolean
+                                        selfHeal:
+                                          description: 'SelfHeal enables auto-syncing if  (default: false)'
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      description: Retry controls failed sync retry behavior
+                                      properties:
+                                        backoff:
+                                          description: Backoff is a backoff strategy
+                                          properties:
+                                            duration:
+                                              description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                                              type: string
+                                            factor:
+                                              description: Factor is a factor to multiply the base duration after each failed retry
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                                              type: string
+                                          type: object
+                                        limit:
+                                          description: Limit is the maximum number of attempts when retrying a container
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      description: Options allow you to specify whole app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      required:
+                      - repoURL
+                      - revision
+                      type: object
+                    list:
+                      description: ListGenerator include items info
+                      properties:
+                        elements:
+                          items:
+                            description: ListGeneratorElement include cluster and url info
+                            properties:
+                              cluster:
+                                type: string
+                              url:
+                                type: string
+                              values:
+                                additionalProperties:
+                                  type: string
+                                description: Values contains key/value pairs which are passed directly as parameters to the template
+                                type: object
+                            required:
+                            - cluster
+                            - url
+                            type: object
+                          type: array
+                        template:
+                          description: ApplicationSetTemplate represents argocd ApplicationSpec
+                          properties:
+                            metadata:
+                              description: ApplicationSetTemplateMeta represents the Argo CD application fields that may be used for Applications generated from the ApplicationSet (based on metav1.ObjectMeta)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+                              properties:
+                                destination:
+                                  description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+                                  properties:
+                                    name:
+                                      description: Name of the destination cluster which can be used instead of server (url) field
+                                      type: string
+                                    namespace:
+                                      description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                                      type: string
+                                    server:
+                                      description: Server overrides the environment server value in the ksonnet app.yaml
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  description: IgnoreDifferences controls resources fields which should be ignored during comparison
+                                  items:
+                                    description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
+                                    properties:
+                                      group:
+                                        type: string
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - jsonPointers
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  description: Project is a application project name. Empty name means that application belongs to 'default' project.
+                                  type: string
+                                revisionHistoryLimit:
+                                  description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+                                  format: int64
+                                  type: integer
+                                source:
+                                  description: Source is a reference to the location ksonnet application definition
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory specific options
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        jsonnet:
+                                          description: ApplicationSourceJsonnet holds jsonnet specific options
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet External Variables
+                                              items:
+                                                description: JsonnetVar is a jsonnet variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet Top-level Arguments
+                                              items:
+                                                description: JsonnetVar is a jsonnet variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        fileParameters:
+                                          description: FileParameters are file parameters to the helm template
+                                          items:
+                                            description: HelmFileParameter is a file parameter to a helm template
+                                            properties:
+                                              name:
+                                                description: Name is the name of the helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path value for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        parameters:
+                                          description: Parameters are parameters to the helm template
+                                          items:
+                                            description: HelmParameter is a parameter to a helm template
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        releaseName:
+                                          description: The Helm release name. If omitted it will use the application name
+                                          type: string
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm value files to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values is Helm values, typically defined as a block
+                                          type: string
+                                        version:
+                                          description: Version is the Helm version to use for templating with
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      description: Ksonnet holds ksonnet specific options
+                                      properties:
+                                        environment:
+                                          description: Environment is a ksonnet application environment name
+                                          type: string
+                                        parameters:
+                                          description: Parameters are a list of ksonnet component parameter override values
+                                          items:
+                                            description: KsonnetParameter is a ksonnet component parameter
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific options
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations adds additional kustomize commonAnnotations
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels adds additional kustomize commonLabels
+                                          type: object
+                                        images:
+                                          description: Images are kustomize image overrides
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended to resources for kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended to resources for kustomize apps
+                                          type: string
+                                        version:
+                                          description: Version contains optional Kustomize version
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within the Git repository
+                                      type: string
+                                    plugin:
+                                      description: ConfigManagementPlugin holds config management plugin specific options
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                description: the name, usually uppercase
+                                                type: string
+                                              value:
+                                                description: the value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      description: RepoURL is the repository URL of the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  description: SyncPolicy controls when a sync will be performed
+                                  properties:
+                                    automated:
+                                      description: Automated will keep an application synced to the target revision
+                                      properties:
+                                        allowEmpty:
+                                          description: 'AllowEmpty allows apps have zero live resources (default: false)'
+                                          type: boolean
+                                        prune:
+                                          description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                                          type: boolean
+                                        selfHeal:
+                                          description: 'SelfHeal enables auto-syncing if  (default: false)'
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      description: Retry controls failed sync retry behavior
+                                      properties:
+                                        backoff:
+                                          description: Backoff is a backoff strategy
+                                          properties:
+                                            duration:
+                                              description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                                              type: string
+                                            factor:
+                                              description: Factor is a factor to multiply the base duration after each failed retry
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                                              type: string
+                                          type: object
+                                        limit:
+                                          description: Limit is the maximum number of attempts when retrying a container
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      description: Options allow you to specify whole app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      required:
+                      - elements
+                      type: object
+                  type: object
+                type: array
+              syncPolicy:
+                description: ApplicationSetSyncPolicy configures how generated Applications will relate to their ApplicationSet.
+                properties:
+                  skipPrune:
+                    description: SkipPrune will disable the default behavior which will delete Applications that are no longer being generated for the ApplicationSet which created them, or the ApplicationSet itself is deleted. If SkipPrune is set to true, these Applications will be orphaned but continue to exist.
+                    type: boolean
+                type: object
+              template:
+                description: ApplicationSetTemplate represents argocd ApplicationSpec
+                properties:
+                  metadata:
+                    description: ApplicationSetTemplateMeta represents the Argo CD application fields that may be used for Applications generated from the ApplicationSet (based on metav1.ObjectMeta)
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  spec:
+                    description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+                    properties:
+                      destination:
+                        description: Destination overrides the kubernetes server and namespace defined in the environment ksonnet app.yaml
+                        properties:
+                          name:
+                            description: Name of the destination cluster which can be used instead of server (url) field
+                            type: string
+                          namespace:
+                            description: Namespace overrides the environment namespace value in the ksonnet app.yaml
+                            type: string
+                          server:
+                            description: Server overrides the environment server value in the ksonnet app.yaml
+                            type: string
+                        type: object
+                      ignoreDifferences:
+                        description: IgnoreDifferences controls resources fields which should be ignored during comparison
+                        items:
+                          description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
+                          properties:
+                            group:
+                              type: string
+                            jsonPointers:
+                              items:
+                                type: string
+                              type: array
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - jsonPointers
+                          - kind
+                          type: object
+                        type: array
+                      info:
+                        description: Infos contains a list of useful information (URLs, email addresses, and plain text) that relates to the application
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      project:
+                        description: Project is a application project name. Empty name means that application belongs to 'default' project.
+                        type: string
+                      revisionHistoryLimit:
+                        description: This limits this number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+                        format: int64
+                        type: integer
+                      source:
+                        description: Source is a reference to the location ksonnet application definition
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                type: string
+                              jsonnet:
+                                description: ApplicationSourceJsonnet holds jsonnet specific options
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External Variables
+                                    items:
+                                      description: JsonnetVar is a jsonnet variable
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level Arguments
+                                    items:
+                                      description: JsonnetVar is a jsonnet variable
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter to a helm template
+                                  properties:
+                                    name:
+                                      description: Name is the name of the helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path value for the helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              parameters:
+                                description: Parameters are parameters to the helm template
+                                items:
+                                  description: HelmParameter is a parameter to a helm template
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              releaseName:
+                                description: The Helm release name. If omitted it will use the application name
+                                type: string
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values is Helm values, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for templating with
+                                type: string
+                            type: object
+                          ksonnet:
+                            description: Ksonnet holds ksonnet specific options
+                            properties:
+                              environment:
+                                description: Environment is a ksonnet application environment name
+                                type: string
+                              parameters:
+                                description: Parameters are a list of ksonnet component parameter override values
+                                items:
+                                  description: KsonnetParameter is a ksonnet component parameter
+                                  properties:
+                                    component:
+                                      type: string
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations adds additional kustomize commonAnnotations
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels adds additional kustomize commonLabels
+                                type: object
+                              images:
+                                description: Images are kustomize image overrides
+                                items:
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources for kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources for kustomize apps
+                                type: string
+                              version:
+                                description: Version contains optional Kustomize version
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository
+                            type: string
+                          plugin:
+                            description: ConfigManagementPlugin holds config management plugin specific options
+                            properties:
+                              env:
+                                items:
+                                  properties:
+                                    name:
+                                      description: the name, usually uppercase
+                                      type: string
+                                    value:
+                                      description: the value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the repository URL of the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the commit, tag, or branch in which to sync the application to. If omitted, will sync to HEAD
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                      syncPolicy:
+                        description: SyncPolicy controls when a sync will be performed
+                        properties:
+                          automated:
+                            description: Automated will keep an application synced to the target revision
+                            properties:
+                              allowEmpty:
+                                description: 'AllowEmpty allows apps have zero live resources (default: false)'
+                                type: boolean
+                              prune:
+                                description: 'Prune will prune resources automatically as part of automated sync (default: false)'
+                                type: boolean
+                              selfHeal:
+                                description: 'SelfHeal enables auto-syncing if  (default: false)'
+                                type: boolean
+                            type: object
+                          retry:
+                            description: Retry controls failed sync retry behavior
+                            properties:
+                              backoff:
+                                description: Backoff is a backoff strategy
+                                properties:
+                                  duration:
+                                    description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                                    type: string
+                                  factor:
+                                    description: Factor is a factor to multiply the base duration after each failed retry
+                                    format: int64
+                                    type: integer
+                                  maxDuration:
+                                    description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                                    type: string
+                                type: object
+                              limit:
+                                description: Limit is the maximum number of attempts when retrying a container
+                                format: int64
+                                type: integer
+                            type: object
+                          syncOptions:
+                            description: Options allow you to specify whole app sync-options
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    required:
+                    - destination
+                    - project
+                    - source
+                    type: object
+                required:
+                - metadata
+                - spec
+                type: object
+            required:
+            - generators
+            - template
+            type: object
+          status:
+            description: ApplicationSetStatus defines the observed state of ApplicationSet
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: argocd-applicationset-controller
+    app.kubernetes.io/part-of: argocd-applicationset
+  name: argocd-applicationset-controller
+  namespace: argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: argocd-applicationset-controller
+    app.kubernetes.io/part-of: argocd-applicationset
+  name: argocd-applicationset-controller
+  namespace: argocd
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - appprojects
+  - applicationsets
+  - applicationsets/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applicationsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: argocd-applicationset-controller
+    app.kubernetes.io/part-of: argocd-applicationset
+  name: argocd-applicationset-controller
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-applicationset-controller
+subjects:
+- kind: ServiceAccount
+  name: argocd-applicationset-controller
+  namespace: argocd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: argocd-applicationset-controller
+    app.kubernetes.io/part-of: argocd-applicationset
+  name: argocd-applicationset-controller
+  namespace: argocd
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-applicationset-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-applicationset-controller
+    spec:
+      containers:
+      - command:
+        - applicationset-controller
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/argocdapplicationset/argocd-applicationset:v0.1.0
+        imagePullPolicy: Always
+        name: argocd-applicationset-controller
+        volumeMounts:
+        - mountPath: /app/config/ssh
+          name: ssh-known-hosts
+        - mountPath: /app/config/tls
+          name: tls-certs
+        - mountPath: /app/config/gpg/source
+          name: gpg-keys
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
+      serviceAccountName: argocd-applicationset-controller
+      volumes:
+      - configMap:
+          name: argocd-ssh-known-hosts-cm
+        name: ssh-known-hosts
+      - configMap:
+          name: argocd-tls-certs-cm
+        name: tls-certs
+      - configMap:
+          name: argocd-gpg-keys-cm
+        name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring


### PR DESCRIPTION
- Introduced CustomResourceDefinition for ApplicationSet with v1alpha1 schema.
- Added ServiceAccount, Role, RoleBinding, and Deployment for the ApplicationSet controller.
- Configured necessary RBAC permissions for managing applications and related resources.
- Set up deployment specifications including environment variables and volume mounts for SSH, TLS, and GPG configurations.