### PR TITLE
Adjust ExternalSecret refresh intervals to 24h

### DIFF
--- a/apps/dawarich/secrets.yaml
+++ b/apps/dawarich/secrets.yaml
@@ -9,7 +9,7 @@ spec:
     name: secret-store-provider
     kind: ClusterSecretStore # or ClusterSecretStore
 
-  refreshInterval: "1h"
+  refreshInterval: "24h"
 
   target:
     name: dawarich-secrets

--- a/apps/immich/external-secret.yaml
+++ b/apps/immich/external-secret.yaml
@@ -13,7 +13,7 @@ spec:
     name: secret-store-provider
     kind: ClusterSecretStore # or ClusterSecretStore
 
-  # refreshInterval: "1h"
+  refreshInterval: "24h"
 
   target:
     name: immich-external-secrets

--- a/apps/n8n/helmfile.yaml
+++ b/apps/n8n/helmfile.yaml
@@ -118,6 +118,7 @@ releases:
               secretStoreRef:
                 name: secret-store-provider
                 kind: ClusterSecretStore # or ClusterSecretStore
+              refreshInterval: "24h"
               target:
                 name: n8n-key
                 deletionPolicy: Retain

--- a/apps/wordpress/external-secret.yaml
+++ b/apps/wordpress/external-secret.yaml
@@ -9,7 +9,7 @@ spec:
     name: secret-store-provider
     kind: ClusterSecretStore # or ClusterSecretStore
 
-  refreshInterval: "1h"
+  refreshInterval: "24h"
 
   target:
     name: wordpress-external-secrets

--- a/middlewares/couchdb/external-secret.yaml
+++ b/middlewares/couchdb/external-secret.yaml
@@ -9,7 +9,7 @@ spec:
     name: secret-store-provider
     kind: ClusterSecretStore # or ClusterSecretStore
 
-  refreshInterval: "1h"
+  refreshInterval: "24h"
 
   target:
     name: couchdb-external-secrets

--- a/middlewares/grafana/grafana-external-secrets.yaml
+++ b/middlewares/grafana/grafana-external-secrets.yaml
@@ -9,7 +9,7 @@ spec:
     name: secret-store-provider
     kind: ClusterSecretStore # or ClusterSecretStore
 
-  refreshInterval: "1h"
+  refreshInterval: "24h"
 
   target:
     name: grafana-external-secrets

--- a/middlewares/pg/pg-external-secrets.yaml
+++ b/middlewares/pg/pg-external-secrets.yaml
@@ -9,7 +9,7 @@ spec:
     name: secret-store-provider
     kind: ClusterSecretStore # or ClusterSecretStore
 
-  refreshInterval: "1h"
+  refreshInterval: "24h"
 
   target:
     name: pg-superuser


### PR DESCRIPTION
## Summary
- update the ExternalSecret refresh interval to 24 hours for CouchDB, Grafana, WordPress, Dawarich, and PostgreSQL middlewares
- enable a 24-hour refresh interval for the Immich ExternalSecret
- ensure the n8n ExternalSecret extra manifest specifies a 24-hour refresh interval

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da4a79bb58832e9ddf155240ea1c66